### PR TITLE
Fix CombatLogX V11 hook.

### DIFF
--- a/src/io/github/gronnmann/coinflipper/hook/HookCombatLogX11.java
+++ b/src/io/github/gronnmann/coinflipper/hook/HookCombatLogX11.java
@@ -2,20 +2,29 @@ package io.github.gronnmann.coinflipper.hook;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 
 import com.github.sirblobman.combatlogx.api.ICombatLogX;
-import com.github.sirblobman.combatlogx.api.ICombatManager;
+import com.github.sirblobman.combatlogx.api.manager.ICombatManager;
 
 public final class HookCombatLogX11 {
-	private HookCombatLogX11() {}
 	private static final HookCombatLogX11 hook = new HookCombatLogX11();
+
 	public static HookCombatLogX11 getHook(){
 		return hook;
 	}
 
 	private ICombatManager combatManager;
+
+	private HookCombatLogX11() {
+		// Empty Constructor
+	}
+
 	public void register(){
-		ICombatLogX combatLogX = (ICombatLogX) Bukkit.getPluginManager().getPlugin("CombatLogX");
+		PluginManager pluginManager = Bukkit.getPluginManager();
+		Plugin plugin = pluginManager.getPlugin("CombatLogX");
+		ICombatLogX combatLogX = (ICombatLogX) plugin;
 		this.combatManager = combatLogX.getCombatManager();
 	}
 	

--- a/src/io/github/gronnmann/coinflipper/hook/HookManager.java
+++ b/src/io/github/gronnmann/coinflipper/hook/HookManager.java
@@ -108,7 +108,7 @@ public class HookManager {
 		if (this.isHooked(HookType.CombatLogX)){
 			String version = Bukkit.getPluginManager().getPlugin("CombatLogX").getDescription().getVersion();
 			if(version.startsWith("10")) return HookCombatLogX10.getHook().isTagged(player);
-			else if(version.startsWith("11")) HookCombatLogX11.getHook().isTagged(player);
+			else if(version.startsWith("11")) return HookCombatLogX11.getHook().isTagged(player);
 		}
 		
 		return false;


### PR DESCRIPTION
CombatLogX V11 is now released and the API changed a bit. I have updated to hook classes.